### PR TITLE
Remove docs prefix from MkDocs navigation paths

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,12 @@
 ﻿site_name: Cimeika Knowledge
 site_url: https://example.org/
 nav:
-  - Home: docs/index.md
+  - Home: index.md
   - Concepts:
-      - Overview: docs/concepts/index.md
+      - Overview: concepts/index.md
   - Research:
-      - Overview: docs/research/index.md
+      - Overview: research/index.md
   - Playbooks:
-      - Overview: docs/playbooks/index.md
+      - Overview: playbooks/index.md
 theme:
   name: material


### PR DESCRIPTION
## Summary
- drop `docs/` prefix from MkDocs `nav` paths
- retain existing `site_name` and `theme` settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f2c87734832388e505eddf195351

## Зведення від Sourcery

Документація:
- Прибрати префікс 'docs/' з елементів навігації Home, Concepts, Research та Playbooks у mkdocs.yml

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Drop 'docs/' prefix from Home, Concepts, Research, and Playbooks nav entries in mkdocs.yml

</details>