### PR TITLE
Move integration workflow and use env token

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,6 @@ jobs:
         cp -r ../ciwiki/* ./docs/
         git add .
         git commit -m "Автоматичне оновлення з ciwiki"
-        git push https://<YOUR_TOKEN>@github.com/Ihorog/cimeika.git main
+        git push https://$YOUR_TOKEN@github.com/Ihorog/cimeika.git main
       env:
         YOUR_TOKEN: ${{ secrets.CIMEIKA_TOKEN }}


### PR DESCRIPTION
## Summary
- move integration workflow into `.github/workflows`
- use `$YOUR_TOKEN` in push command

## Testing
- `npm test`
- `gh secret list` *(fails: requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f67807a8832394efe84eedccab94

## Підсумок від Sourcery

Перемістити робочий процес інтеграції GitHub Actions до стандартної директорії робочих процесів та оновити крок push для використання токена на основі змінної середовища.

Покращення:
- Перемістити робочий процес інтеграції до директорії .github/workflows
- Налаштувати команду Git push для використання змінної середовища YOUR_TOKEN замість жорстко закодованого токена

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move the integration GitHub Actions workflow into the standard workflows directory and update the push step to utilize an environment-based token

Enhancements:
- Relocate the integration workflow into .github/workflows directory
- Configure the Git push command to use the YOUR_TOKEN environment variable instead of a hardcoded token

</details>