### PR TITLE
Add MIT license and update docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cimeika
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # ciwiki
 Cimeika documentation
+
+## License
+This project is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "description": "",
   "dependencies": {
     "axios": "^1.7.9",


### PR DESCRIPTION
## Summary
- Add MIT license file
- Update README with license information
- Set `package.json` license to MIT

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f67cf6b883238bdc55319b26c529

## Підсумок від Sourcery

Додано ліцензію MIT до проєкту та оновлено документацію й метадані пакунка відповідно.

Документація:
- Додано розділ "Ліцензія" до README з посиланням на ліцензію MIT.

Технічні завдання:
- Додано файл MIT LICENSE до репозиторію.
- Змінено поле license в package.json з ISC на MIT.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MIT license to the project and update documentation and package metadata accordingly.

Documentation:
- Add a License section to README referencing the MIT license.

Chores:
- Add MIT LICENSE file to the repository.
- Change the license field in package.json from ISC to MIT.

</details>