### PR TITLE
Add documentation for core modules

### DIFF
--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -1,0 +1,10 @@
+---
+id: ci
+title: "Ci (Центральний Інтелектуальний асистент)"
+tags: []
+updated: 2025-08-21
+summary: Central assistant coordinating platform features.
+cover: ''
+---
+# Ci (Центральний Інтелектуальний асистент)
+Основний координатор, що забезпечує інтуїтивний доступ до функцій Cimeika.

--- a/docs/malya/index.md
+++ b/docs/malya/index.md
@@ -1,0 +1,10 @@
+---
+id: malya
+title: "Malya (Маля)"
+tags: []
+updated: 2025-08-21
+summary: Creative space for children and adults.
+cover: ''
+---
+# Malya (Маля)
+Простір для розвитку творчості через ігри, завдання та сімейні проєкти.

--- a/docs/nastrij/index.md
+++ b/docs/nastrij/index.md
@@ -1,0 +1,10 @@
+---
+id: nastrij
+title: "Nastrij (Настрій)"
+tags: []
+updated: 2025-08-21
+summary: Support for emotional well-being and mood tracking.
+cover: ''
+---
+# Nastrij (Настрій)
+Модуль для підтримки емоційного здоров'я, медитацій і рекомендацій.

--- a/docs/podija/index.md
+++ b/docs/podija/index.md
@@ -1,0 +1,10 @@
+---
+id: podija
+title: "PoDija (ПоДія)"
+tags: []
+updated: 2025-08-21
+summary: Tool for organizing events and tasks.
+cover: ''
+---
+# PoDija (ПоДія)
+Інструмент для планування зустрічей, свят та завдань.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,5 +8,13 @@ nav:
       - Overview: research/index.md
   - Playbooks:
       - Overview: playbooks/index.md
+  - PoDija:
+      - Overview: podija/index.md
+  - Malya:
+      - Overview: malya/index.md
+  - Nastrij:
+      - Overview: nastrij/index.md
+  - Ci:
+      - Overview: ci/index.md
 theme:
   name: material


### PR DESCRIPTION
## Summary
- add docs for PoDija, Malya, Nastrij, and Ci modules with YAML front matter
- register new sections in mkdocs navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6f68591208323bf8444b9897e22db

## Підсумок від Sourcery

Додати початкову документацію для основних модулів PoDija, Malya, Nastrij та Ci та зареєструвати їх у навігації сайту

Збірка:
- Оновити навігацію mkdocs.yml для включення розділів PoDija, Malya, Nastrij та Ci

Документація:
- Додати сторінки документації з YAML-front-matter для модулів PoDija, Malya, Nastrij та Ci

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add initial documentation for core PoDija, Malya, Nastrij, and Ci modules and register them in the site navigation

Build:
- Update mkdocs.yml navigation to include PoDija, Malya, Nastrij, and Ci sections

Documentation:
- Add YAML-front-matter documentation pages for PoDija, Malya, Nastrij, and Ci modules

</details>