### PR TITLE
docs: fix workflow paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-codex/document-ciwiki-installation-and-usage-instructions
 # CiWiki
 
 CiWiki is the knowledge base for the Cimeika ecosystem—an interactive platform for organizing time, creativity, emotional state and communication.
@@ -30,7 +29,7 @@ CiWiki is the knowledge base for the Cimeika ecosystem—an interactive platform
 
 - Documentation: see [docs/](docs/)
 - Tests: see [tests/](tests/) and execute with `npm test`
-- Deployment: GitHub Actions workflow in [workflows/integration.yml](workflows/integration.yml); this copies docs into the `cimeika` repository.
+- Deployment: GitHub Actions workflow in [.github/workflows/integration.yml](.github/workflows/integration.yml); this copies docs into the `cimeika` repository.
 
 ## Project Structure
 
@@ -38,7 +37,7 @@ CiWiki is the knowledge base for the Cimeika ecosystem—an interactive platform
 .
 ├── docs/         # Documentation markdown sources
 ├── tests/        # Jest test suite
-├── workflows/    # CI/CD configuration
+├── .github/workflows/    # CI/CD configuration
 ├── mkdocs.yml    # MkDocs configuration
 ├── package.json  # Node.js project metadata
 └── README.md


### PR DESCRIPTION
## Summary
- remove leftover installation reference
- clarify integration workflow path
- document `.github/workflows` directory structure

## Testing
- `npm test`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68a74a029b8083238dd5f1061c1ce4d4

## Підсумок від Sourcery

Оновити README, щоб видалити застарілий текст, виправити шляхи до файлів робочих процесів та відобразити каталог .github/workflows

Документація:
- Видалити залишкові посилання на встановлення на початку README
- Оновити шлях робочого процесу інтеграції на .github/workflows/integration.yml
- Змінити розділ структури проекту, щоб посилатися на каталог .github/workflows

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update README to remove obsolete text, correct workflow file paths, and reflect the .github/workflows directory

Documentation:
- Remove leftover installation reference at the top of the README
- Update integration workflow path to .github/workflows/integration.yml
- Change project structure section to reference the .github/workflows directory

</details>