### PR TITLE
Refine integration workflow copy and commit process

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,14 +17,15 @@ jobs:
       run: |
         git clone https://github.com/Ihorog/cimeika.git
         cd cimeika
+        mkdir -p docs
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
 
     - name: Copy files from ciwiki
       run: |
-        cp -r ../ciwiki/* ./docs/
+        cp -r ../ciwiki/docs/* ./docs/
         git add .
-        git commit -m "Автоматичне оновлення з ciwiki"
+        git diff --quiet || git commit -m "Автоматичне оновлення з ciwiki"
         git push https://$YOUR_TOKEN@github.com/Ihorog/cimeika.git main
       env:
         YOUR_TOKEN: ${{ secrets.CIMEIKA_TOKEN }}


### PR DESCRIPTION
## Summary
- Ensure docs directory exists before copying into it
- Copy only docs subdirectory from ciwiki and skip commit when no changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74a0711c083238f4e65a70f52c763

## Підсумок від Sourcery

Удосконалити робочий процес інтеграції GitHub Actions, щоб переконатися, що цільова директорія `docs` існує, копіювати лише піддиректорію `docs` з ciwiki, та пропускати коміти, коли немає змін

CI:
- Створити директорію `docs`, якщо вона не існує, перед копіюванням
- Копіювати лише піддиректорію `docs` з репозиторію ciwiki в `docs`
- Перевіряти наявність змін і комітити лише при наявності оновлень, щоб уникнути порожніх комітів

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the GitHub Actions integration workflow to ensure the target docs directory exists, copy only the docs subdirectory from ciwiki, and skip commits when there are no changes

CI:
- Create the docs directory if it does not exist before copying
- Copy only the docs subdirectory from the ciwiki repository into docs
- Check for changes and only commit when there are updates to avoid empty commits

</details>