### PR TITLE
Refine MkDocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,13 +1,16 @@
 site_name: CiWiki
+site_url: https://www.cimeika.com.ua/
 theme:
   name: material
+  logo: media/logo/ci_logo.svg
+  favicon: media/logo/favicon.png
 nav:
-  - Головна: docs/index.md
-  - Концепти: docs/concepts/index.md
-  - Казкар: docs/kazkar/index.md
-  - Ігрові легенди: docs/kazkar/legends/index.md
-  - Плейбуки: docs/playbooks/index.md
-  - Дослідження: docs/research/index.md
-  - Nastrij: docs/nastrij/index.md
-  - Malya: docs/malya/index.md
-  - Podija: docs/podija/index.md
+  - Головна: index.md
+  - Концепти: concepts/index.md
+  - Казкар: kazkar/index.md
+  - Ігрові легенди: kazkar/legends/index.md
+  - Плейбуки: playbooks/index.md
+  - Дослідження: research/index.md
+  - Nastrij: nastrij/index.md
+  - Malya: malya/index.md
+  - Podija: podija/index.md


### PR DESCRIPTION
## Summary
- set site URL for Cimeika documentation
- add logo and favicon paths in theme settings
- simplify navigation links by removing `docs/` prefix

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a88e813e1083238f852512f4ecf31a

## Підсумок від Sourcery

Вдосконалення конфігурації MkDocs шляхом встановлення URL-адреси сайту, додавання логотипу та фавікону, а також спрощення шляхів навігації.

Документація:
- Зазначити site_url для документації Cimeika
- Додати налаштування логотипу та фавікону до теми Material
- Видалити префікс "docs/" з навігаційних посилань для спрощення шляхів

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the MkDocs configuration by setting the site URL, adding logo and favicon, and simplifying navigation paths

Documentation:
- Specify the site_url for Cimeika documentation
- Add logo and favicon settings to the Material theme
- Remove the "docs/" prefix from navigation links to simplify paths

</details>